### PR TITLE
Provide empty implementations in base classes

### DIFF
--- a/codegen/templates/ServiceInterfaceTemplate.hpp
+++ b/codegen/templates/ServiceInterfaceTemplate.hpp
@@ -70,12 +70,12 @@ protected:
     # Generate callback functions for each service output.
     for output in service["outputs"]:
         if output['is_array']:
-            cog.outl(f"virtual void {output['callback_name']}(const {output['type']}* new_value, uint32_t length) = 0;")
+            cog.outl(f"virtual void {output['callback_name']}(const {output['type']}* new_value, uint32_t length) {{}};")
         else:
-            cog.outl(f"virtual void {output['callback_name']}(const {output['type']} &new_value) = 0;")
+            cog.outl(f"virtual void {output['callback_name']}(const {output['type']} &new_value) {{}};")
     ]]]*/
-    virtual void OnExampleOutput1Changed(const char* new_value, uint32_t length) = 0;
-    virtual void OnExampleOutput2Changed(const uint32_t &new_value) = 0;
+    virtual void OnExampleOutput1Changed(const char* new_value, uint32_t length) {};
+    virtual void OnExampleOutput2Changed(const uint32_t &new_value) {};
     //[[[end]]]
 
 
@@ -91,4 +91,3 @@ private:
 
 
 #endif
-

--- a/codegen/templates/ServiceTemplate.hpp
+++ b/codegen/templates/ServiceTemplate.hpp
@@ -164,12 +164,12 @@ protected:
     # Generate callback functions for each input.
     for input in service["inputs"]:
         if input['is_array']:
-            cog.outl(f"virtual bool {input['callback_name']}(const {input['type']}* new_value, uint32_t length) = 0;")
+            cog.outl(f"virtual bool {input['callback_name']}(const {input['type']}* new_value, uint32_t length) {{ return true; }};")
         else:
-            cog.outl(f"virtual bool {input['callback_name']}(const {input['type']} &new_value) = 0;")
+            cog.outl(f"virtual bool {input['callback_name']}(const {input['type']} &new_value) {{ return true; }};")
     ]]]*/
-    virtual bool OnExampleInput1Changed(const char* new_value, uint32_t length) = 0;
-    virtual bool OnExampleInput2Changed(const uint32_t &new_value) = 0;
+    virtual bool OnExampleInput1Changed(const char* new_value, uint32_t length) { return true; };
+    virtual bool OnExampleInput2Changed(const uint32_t &new_value) { return true; };
     //[[[end]]]
 
     /*[[[cog
@@ -212,4 +212,3 @@ protected:
 
 
 #endif
-


### PR DESCRIPTION
Service providers might choose to ignore inputs.
Service clients might choose to ignore outputs.
Include empty implementations so they don't have to.