### PR TITLE
More default implementations

### DIFF
--- a/codegen/templates/ServiceInterfaceTemplate.cpp
+++ b/codegen/templates/ServiceInterfaceTemplate.cpp
@@ -101,15 +101,3 @@ bool ServiceTemplateInterfaceBase::SendExampleInput2(const uint32_t &data) {
     return SendData(1, &data, sizeof(uint32_t), false);
 }
 //[[[end]]]
-
-/*[[[cog
-cog.outl(f"void {service['interface_class_name']}::OnServiceConnected(uint16_t service_id) {{}};")
-cog.outl(f"void {service['interface_class_name']}::OnTransactionStart(uint64_t timestamp) {{}};")
-cog.outl(f"void {service['interface_class_name']}::OnTransactionEnd() {{}};")
-cog.outl(f"void {service['interface_class_name']}::OnServiceDisconnected(uint16_t service_id) {{}};")
-]]]*/
-void ServiceTemplateInterfaceBase::OnServiceConnected(uint16_t service_id) {};
-void ServiceTemplateInterfaceBase::OnTransactionStart(uint64_t timestamp) {};
-void ServiceTemplateInterfaceBase::OnTransactionEnd() {};
-void ServiceTemplateInterfaceBase::OnServiceDisconnected(uint16_t service_id) {};
-//[[[end]]]

--- a/codegen/templates/ServiceInterfaceTemplate.hpp
+++ b/codegen/templates/ServiceInterfaceTemplate.hpp
@@ -81,11 +81,7 @@ protected:
 
 
 private:
-	void OnData(uint16_t service_id, uint64_t timestamp, uint16_t target_id, const void *payload, size_t buflen) final;
-  void OnServiceConnected(uint16_t service_id) override;
-  void OnTransactionStart(uint64_t timestamp) override;
-  void OnTransactionEnd() override;
-  void OnServiceDisconnected(uint16_t service_id) override;
+  void OnData(uint16_t service_id, uint64_t timestamp, uint16_t target_id, const void *payload, size_t buflen) final;
 };
 
 

--- a/libxbot-service-interface/include/xbot-service-interface/ServiceIO.hpp
+++ b/libxbot-service-interface/include/xbot-service-interface/ServiceIO.hpp
@@ -18,17 +18,17 @@ namespace xbot::serviceif {
    * Called whenever a service is connected.
    * Connected means that it was discovered and claimed successfully.
    */
-  virtual void OnServiceConnected(uint16_t service_id) = 0;
+  virtual void OnServiceConnected(uint16_t service_id) {};
 
   /**
    * Called whenever a new transaction starts
    */
-  virtual void OnTransactionStart(uint64_t timestamp) = 0;
+  virtual void OnTransactionStart(uint64_t timestamp) {};
 
   /**
    * Called whenever a transaction was finished
    */
-  virtual void OnTransactionEnd() = 0;
+  virtual void OnTransactionEnd() {};
 
   /**
    * Called whenever a packet is received from the specified service.
@@ -47,7 +47,7 @@ namespace xbot::serviceif {
    * send a configuration transaction to the requesting service
    * @param service_id service id
    */
-  virtual bool OnConfigurationRequested(uint16_t service_id) = 0;
+  virtual bool OnConfigurationRequested(uint16_t service_id) { return true; };
 
   /**
    * Called whenever a service is disconnected.
@@ -56,7 +56,7 @@ namespace xbot::serviceif {
    * Then OnData will be called again as expected.
    * @param service_id the service's id
    */
-  virtual void OnServiceDisconnected(uint16_t service_id) = 0;
+  virtual void OnServiceDisconnected(uint16_t service_id) {};
  };
 
  /**

--- a/libxbot-service-interface/src/PlotJugglerBridge.cpp
+++ b/libxbot-service-interface/src/PlotJugglerBridge.cpp
@@ -114,12 +114,6 @@ void PlotJugglerBridge::OnServiceConnected(uint16_t service_id) {
   spdlog::info("PJB: Service Connected! ID: {}", service_id);
 }
 
-void PlotJugglerBridge::OnTransactionStart(uint64_t timestamp) {
-}
-
-void PlotJugglerBridge::OnTransactionEnd() {
-}
-
 void PlotJugglerBridge::OnData(uint16_t service_id, uint64_t timestamp,
                                uint16_t target_id, const void *payload,
                                size_t buflen) {
@@ -183,10 +177,6 @@ void PlotJugglerBridge::OnData(uint16_t service_id, uint64_t timestamp,
 
 void PlotJugglerBridge::OnServiceDisconnected(uint16_t service_id) {
   spdlog::info("PJB: OnServiceDisconnected. ID: {}", service_id);
-}
-
-bool PlotJugglerBridge::OnConfigurationRequested(uint16_t service_id) {
-  return false;
 }
 
 PlotJugglerBridge::PlotJugglerBridge(xbot::serviceif::Context ctx) : ctx(ctx) {

--- a/libxbot-service-interface/src/PlotJugglerBridge.hpp
+++ b/libxbot-service-interface/src/PlotJugglerBridge.hpp
@@ -43,16 +43,10 @@ public:
 
  void OnServiceConnected(uint16_t service_id) override;
 
- void OnTransactionStart(uint64_t timestamp) override;
-
- void OnTransactionEnd() override;
-
  void OnData(uint16_t service_id, uint64_t timestamp, uint16_t target_id,
              const void *payload, size_t buflen) override;
 
  void OnServiceDisconnected(uint16_t service_id) override;
-
- bool OnConfigurationRequested(uint16_t service_id) override;
 
 private:
  std::mutex state_mutex_{};

--- a/libxbot-service/include/xbot-service/Service.hpp
+++ b/libxbot-service/include/xbot-service/Service.hpp
@@ -61,25 +61,25 @@ class Service : public ServiceIo {
   bool CommitTransaction();
 
   /**
+   * Called before Configure()
+   */
+  virtual void OnCreate() {};
+
+  /**
    * Called before OnStart
    * @return true, if configuration was success
    */
-  virtual bool Configure() = 0;
+  virtual bool Configure() { return true; };
 
   /**
    * Called after successfully Configure() and before tick() starts
    */
-  virtual void OnStart() = 0;
-
-  /**
-   * Called before Configure()
-   */
-  virtual void OnCreate() = 0;
+  virtual void OnStart() {};
 
   /**
    * Called before reconfiguring the service for cleanup
    */
-  virtual void OnStop() = 0;
+  virtual void OnStop() {};
 
   /**
    * Gets the service name


### PR DESCRIPTION
Most service providers/clients don't need all of them, so they can get rid of boilerplate code.