### PR TITLE
Fix IP introspection issues with multiple interfaces

### DIFF
--- a/libxbot-service-interface/src/Socket.cpp
+++ b/libxbot-service-interface/src/Socket.cpp
@@ -46,8 +46,7 @@ bool get_ip(std::string &ip) {
 
     // Get IP address
     if (ioctl(fd, SIOCGIFADDR, &ifr) < 0) {
-      perror("SIOCGIFADDR");
-      break;
+      continue; // No IP on interface
     }
 
     const char *addrStr = inet_ntoa(reinterpret_cast<struct sockaddr_in *>(&ifr.ifr_addr)->sin_addr);

--- a/libxbot-service/src/portable/linux/socket.cpp
+++ b/libxbot-service/src/portable/linux/socket.cpp
@@ -49,8 +49,7 @@ bool get_ip(char* ip, size_t ip_len) {
 
     // Get IP address
     if (ioctl(fd, SIOCGIFADDR, &ifr) < 0) {
-      perror("SIOCGIFADDR");
-      break;
+      continue; // No IP on interface
     }
 
     const char* addrStr = inet_ntoa(reinterpret_cast<struct sockaddr_in*>(&ifr.ifr_addr)->sin_addr);


### PR DESCRIPTION
If an interface does not have an IP then continue to the next interface instead of bailing out.