### PR TITLE
Add support for optional service configuration registers

### DIFF
--- a/codegen/templates/ServiceTemplate.cpp
+++ b/codegen/templates/ServiceTemplate.cpp
@@ -210,6 +210,8 @@ bool ServiceTemplateBase::SendExampleOutput2(const uint32_t &data) {
     for register in service["registers"]:
         if register['type'] == "blob":
             continue
+        if register.get('optional', False):
+            continue
         cog.outl(f"if(!this->{register['name']}.valid) {{return false;}}")
     cog.outl("return true;")
     cog.outl("}")
@@ -244,6 +246,7 @@ return true;
 void ServiceTemplateBase::loadConfigurationDefaultsImpl() {
 this->Register1.valid = false;
 this->Register2.valid = false;
+this->Register4 Optional.valid = false;
 }
 //[[[end]]]
 

--- a/codegen/templates/service.json
+++ b/codegen/templates/service.json
@@ -40,6 +40,12 @@
       "id": 2,
       "name": "Register3",
       "type": "blob"
+    },
+    {
+      "id": 3,
+      "name": "Register4 Optional",
+      "type": "uint32_t",
+      "optional": true
     }
   ],
   "enums": [

--- a/codegen/xbot_codegen/xbot_codegen.py
+++ b/codegen/xbot_codegen/xbot_codegen.py
@@ -140,6 +140,9 @@ def loadService(path: str) -> dict:
                     raise Exception(f"Default value provided for array register but no default_length provided")
                 register["default_length"] = json_register["default_length"]
 
+        if "optional" in json_register:
+            register["optional"] = json_register["optional"]
+
         service["registers"].append(register)
 
     return service


### PR DESCRIPTION
## Summary
This PR adds support for optional configuration registers in xbot services. Previously, all registers defined in a service were required to be sent in configuration messages, even if some were only needed in specific scenarios.

## Problem
Services like Power Service need configuration values that are only relevant for certain hardware configurations (e.g., `SystemCurrent`, `ChargeVoltage`, `ReChargeVoltage`, ...). The high-level service shouldn't need to send these when they're not applicable, but the framework required all registers to be present.

## Solution
Add an `"optional": true` field to register definitions in service JSON files (instead of twiddle with default values like -1). The code generator will:
1. Skip optional registers in `allRegistersValid()` checks
2. Still initialize them to `valid = false` in `loadConfigurationDefaultsImpl()`
3. Allow business logic to check `.valid` and use robot-specific defaults when not configured

## Usage Example
```json
{
  "id": 5,
  "name": "ChargeVoltage",
  "type": "float",
  "optional": true
}
````

```cpp
// In service implementation
if (power_service.ChargeVoltage.valid) {
    voltage = power_service.ChargeVoltage.value;
} else {
    voltage = robot_config.charge_voltage;  // fallback
}
```
