### PR TITLE
Shutdown callback for service interfaces

### DIFF
--- a/libxbot-service-interface/include/xbot-service-interface/XbotServiceInterface.hpp
+++ b/libxbot-service-interface/include/xbot-service-interface/XbotServiceInterface.hpp
@@ -5,6 +5,8 @@
 #ifndef XBOT_FRAMEWORK_XBOTSERVICEINTERFACE_HPP
 #define XBOT_FRAMEWORK_XBOTSERVICEINTERFACE_HPP
 
+#include <functional>
+
 #include <xbot-service-interface/ServiceDiscovery.hpp>
 #include <xbot-service-interface/ServiceIO.hpp>
 
@@ -14,6 +16,14 @@ struct Context {
   ServiceDiscovery *serviceDiscovery = nullptr;
   void *ctx = nullptr;
 };
+
+using ShutdownCallback = std::function<void()>;
+
+/**
+ * Register a callback invoked after Stop() when SIGINT/SIGTERM is received.
+ * Must be called before Start() if register_signal_handlers is true.
+ */
+void SetShutdownCallback(ShutdownCallback callback);
 
 /**
  * Call this method to start xbot_framework.

--- a/libxbot-service-interface/src/XbotServiceInterface.cpp
+++ b/libxbot-service-interface/src/XbotServiceInterface.cpp
@@ -26,10 +26,18 @@ hub::CrowToSpeedlogHandler logger{};
 std::unique_ptr<PlotJugglerBridge> pjb = nullptr;
 std::unique_ptr<crow::SimpleApp> crow_app = nullptr;
 
+ShutdownCallback shutdown_callback{};
+
 void SignalHandler(int signal) {
   Stop();
+  if (shutdown_callback) {
+    shutdown_callback();
+  }
 }
-struct sigaction act;
+
+void xbot::serviceif::SetShutdownCallback(ShutdownCallback callback) {
+  shutdown_callback = std::move(callback);
+}
 
 xbot::serviceif::Context xbot::serviceif::Start(bool register_handlers, std::string bind_ip, bool start_rest_api) {
   std::unique_lock lk{mtx};
@@ -104,7 +112,9 @@ xbot::serviceif::Context xbot::serviceif::Start(bool register_handlers, std::str
 
   if (register_handlers) {
     // Register own signal handlers
+    struct sigaction act {};
     act.sa_handler = SignalHandler;
+    sigemptyset(&act.sa_mask);
     sigaction(SIGINT, &act, nullptr);
     sigaction(SIGTERM, &act, nullptr);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shutdown callback support to the service interface. Applications can register a callback to run when termination signals (SIGINT/SIGTERM) are received; the callback is invoked after the service stops. The callback must be registered before starting the service when signal handling is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->